### PR TITLE
CD-148455 Delay spawning workers that keep crashing

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -5,6 +5,7 @@ require 'resque/pool/version'
 require 'resque/pool/logging'
 require 'resque/pool/pooled_worker'
 require 'resque/pool/file_or_hash_loader'
+require 'resque/pool/spawn_limiter'
 require 'erb'
 require 'fcntl'
 require 'yaml'
@@ -21,10 +22,18 @@ module Resque
     attr_reader :config
     attr_reader :config_loader
     attr_reader :workers
+    attr_reader :spawn_limiter
 
     def initialize(config_loader=nil)
       init_config(config_loader)
       @workers = Hash.new { |workers, queues| workers[queues] = {} }
+      @delay_spawn_limit = (ENV['DELAY_SPAWN_LIMIT'] || 10).to_i
+      @spawn_limiter = Hash.new do |h, queues|
+        h[queues] = SpawnLimiter.new(
+          delay_step: @delay_spawn_limit,
+          delay_max: (ENV['DELAY_SPAWN_MAX'] || 600).to_i,
+        )
+      end
       procline "(initialized)"
     end
 
@@ -345,6 +354,7 @@ module Resque
     def reap_all_workers(waitpid_flags=Process::WNOHANG)
       @waiting_for_reaper = waitpid_flags == 0
       begin
+        reaped = Hash.new { |h, queues| h[queues] = [] }
         loop do
           # -1, wait for any child process
           wpid, status = Process.waitpid2(-1, waitpid_flags)
@@ -352,9 +362,21 @@ module Resque
 
           if worker = delete_worker(wpid)
             log "Reaped resque worker[#{status.pid}] (status: #{status.exitstatus}) queues: #{worker.queues.join(",")}"
+            reaped[worker.queue_definition] << worker.spawned_at
           else
             # this died before it could be killed, so it's not going to have any extra info
             log "Tried to reap worker [#{status.pid}], but it had already died. (status: #{status.exitstatus})"
+          end
+        end
+
+        # Check if we are having trouble starting
+        now = Time.now
+        reaped.each do |queues, starts|
+          oldest = starts.min
+          if (now - oldest) < @delay_spawn_limit
+            spawn_limiter[queues].delay_spawns
+          else
+            spawn_limiter.delete(queues)
           end
         end
       rescue Errno::ECHILD, QuitNowException
@@ -415,7 +437,16 @@ module Resque
     end
 
     def worker_delta_for(queues)
-      config.fetch(queues, 0) - workers.fetch(queues, []).size
+      delta = config.fetch(queues, 0) - workers.fetch(queues, []).size
+
+      # Only allow downwards deltas while spawn is limited
+      ql = spawn_limiter[queues]
+      if delta > 0 && ql.should_spawn?
+        delta
+      else
+        puts "Delaying spawn until #{ql.delay_until} (failed_count=#{ql.failed_count}) for #{queues}"
+        0
+      end
     end
 
     def pids_for(queues)
@@ -438,6 +469,8 @@ module Resque
 
     def create_worker(queues)
       worker = new_worker(queues)
+      worker.queue_definition = queues
+      worker.spawned_at = Time.now
       worker.pool_master_pid = Process.pid
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']

--- a/lib/resque/pool/pooled_worker.rb
+++ b/lib/resque/pool/pooled_worker.rb
@@ -2,6 +2,9 @@ require 'resque/worker'
 
 class Resque::Pool
   module PooledWorker
+    attr_accessor :queue_definition
+    attr_accessor :spawned_at
+
     attr_accessor :pool_master_pid
     attr_accessor :worker_parent_pid
 

--- a/lib/resque/pool/spawn_limiter.rb
+++ b/lib/resque/pool/spawn_limiter.rb
@@ -1,0 +1,33 @@
+module Resque
+  class Pool
+    class SpawnLimiter
+      attr_reader :delay_until, :failed_count
+
+      def initialize(delay_step:, delay_max:)
+        @delay_step = delay_step
+        @delay_max = delay_max
+        reset
+      end
+
+      def delay_spawns
+        @failed_count += 1
+
+        # Exponential Backoff
+        delay_secs = @delay_step ** @failed_count
+        delay_secs = delay_max if delay_secs > delay_max
+        @delay_until = Time.now.since(delay_secs)
+      end
+
+      def reset
+        @failed_count = 0
+        @delay_until = nil
+      end
+
+      def should_spawn?
+        return true if @delay_until.nil?
+
+        Time.now >= @delay_until
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] @edk 
- [x] @supriya 

If workers crash it will airbrake (since airbrake is attached to rake tasks). resque-pool will immediately try to respawn it. This can cause us to go into a restart-crash-airbrake loop that quickly exhausted our quota.

The code now tries to slow down the restart. It defaults to waiting for 10 seconds, before backing off exponentially. While it's delayed, it will pretend no workers need spawning.