### PR TITLE
CD-148455 Allow worker.spawned_at to be nil. In this we don't do spaw…

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -373,7 +373,7 @@ module Resque
         now = Time.now
         reaped.each do |queues, starts|
           oldest = starts.min
-          if (now - oldest) < @delay_spawn_limit
+          if !oldest.nil? && (now - oldest) < @delay_spawn_limit
             spawn_limiter[queues].delay_spawns
           else
             spawn_limiter.delete(queues)

--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.6.5"
+    VERSION = "0.6.6"
   end
 end


### PR DESCRIPTION
…n limiting

- [x] @johnwu96822 

@revathi-murali  fyi. Maybe you are right, and that error is causing the pool to crash prematurely

FYI, we added `spawned_at` flag to the Worker in `create_worker`. But Avalanche overrode `create_worker` and did not fill in the `spawned_at`.

We are modifying this gem to say that "spawned_at" is now optional. If not set, it will not do any spawn limiting.