### PR TITLE
CD-251244 v0.6.0_fork Add term_and_wait! term_behavior

### DIFF
--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.6.7"
+    VERSION = "0.6.8"
   end
 end

--- a/spec/resque_pool_spec.rb
+++ b/spec/resque_pool_spec.rb
@@ -407,6 +407,17 @@ describe Resque::Pool do
     end
   end
 
+  describe "#term_and_wait!" do
+    subject { resque_pool.term_and_wait!(:TERM) }
+
+    it "should behave as expected" do
+      expect(resque_pool).to receive(:signal_all_workers).with(:USR2)
+      expect(resque_pool).to receive(:signal_all_workers).with(:TERM)
+      expect(resque_pool).to receive(:reap_all_workers).with(0)
+      expect(subject).to eq :break
+    end
+  end
+
   describe "#worker_delta_for" do
     let(:queues) { "queues" }
     let(:spawn_limiter) { Resque::Pool::SpawnLimiter.new(delay_step: 10, delay_max: 360) }


### PR DESCRIPTION
* Also send USR2 to all workers first, so that all workers stop accepting
  new jobs before they are shut down. This prevents a race condition where
  if a worker re-enqueues a job, the job could be taken by a worker that
  is about to be told to shut down by the pool.

- [x] @abdulchaudhrycoupa 
- [ ] @supriya

## Generated Reviewers

<details>
  <summary><em>:warning: Do not modify anything in this section! :warning:</em></summary>
  <em>The content in this section is managed automatically, and any manual changes to it will be ignored and overwritten the next time the code review status is refreshed! View <a href="https://cody.coupa.engineering/repos/coupa/resque-pool/pull/7">this PR</a> on Cody to see the current code review status.</em>
</details>

