### PR TITLE
CD-309298 - v0.6.10: fixes exception during graceful shutdown

### DIFF
--- a/lib/resque/pool.rb
+++ b/lib/resque/pool.rb
@@ -308,11 +308,13 @@ module Resque
       force_term_time = Time.now + period
       Thread.new do
         while Time.now < force_term_time
-          return if quit == true
+          break if quit == true
           sleep 1
         end
-        # Will get here only time time has reached and has not quit
-        signal_all_workers(:TERM)
+        # if quit is true then we have shutdown gracefully
+        # if quit is false then the timer has been reached and we have not quit
+        #   and so now we want to force kill
+        signal_all_workers(:TERM) unless quit
       end
       signal_all_workers(:USR2) # Stop all workers from picking up new jobs
       signal_all_workers(:QUIT) # Stop all workers after finish jobs

--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.6.9"
+    VERSION = "0.6.10"
   end
 end


### PR DESCRIPTION
This fixes an exception during graceful shutdown.
We want to also force kill jobs if the timer has been reached.

To test this locally, use setsid and on a mac use the brew util-linux package
```
/usr/local/opt/util-linux/bin/setsid ./bin/resque-pool --term-graceful-wait-with-period 60
```

- [ ] @johnny-lai

## Generated Reviewers

<details>
  <summary><em>:warning: Do not modify anything in this section! :warning:</em></summary>
  <em>The content in this section is managed automatically, and any manual changes to it will be ignored and overwritten the next time the code review status is refreshed! View <a href="https://cody.coupa.engineering/repos/coupa/resque-pool/pull/9">this PR</a> on Cody to see the current code review status.</em>
</details>

