### PR TITLE
CD-352687 Add term_child to graceful_worker_shutdown_and_wait_period

### DIFF
--- a/lib/resque/pool/version.rb
+++ b/lib/resque/pool/version.rb
@@ -1,5 +1,5 @@
 module Resque
   class Pool
-    VERSION = "0.6.10"
+    VERSION = "0.6.11"
   end
 end


### PR DESCRIPTION
Three levels of processes: pool => worker => job

As of now when k8s wants to shut down a pod, it sends TERM to the pool process, and 15.5 minutes later it sends KILL to pool.

Before this PR, when pool receives TERM, it sends QUIT to workers. Workers upon receiving QUIT, it does not send anything to job and simply wait for the current job to finish. Then 15 minutes (`--term-graceful-wait-with-period` option) later, pool sends TERM to worker, which will send KILL to job. With this scheme, we have no chance of telling the job process to start pausing because no signal is sent to it.

So add the term_child option in the new graceful_worker_shutdown_and_wait_period! method so that we can tell the pool to send TERM to workers first, and 15 minutes later send KILL to workers.

So when we set TERM_CHILD env to true, when worker receives TERM, it immediately sends TERM to the job so the job can start pausing. Then the worker waits for 14.5 minutes (RESQUE_TERM_TIMEOUT env variable) and sends KILL to the job if it did not finish.

- [ ] @gena-admin 
- [ ] @revathi-murali 
- [x] @abdulchaudhrycoupa 
CC: @johnny-lai

## Generated Reviewers

<details>
  <summary><em>:warning: Do not modify anything in this section! :warning:</em></summary>
  <em>The content in this section is managed automatically, and any manual changes to it will be ignored and overwritten the next time the code review status is refreshed! View <a href="https://cody.coupa.engineering/repos/coupa/resque-pool/pull/11">this PR</a> on Cody to see the current code review status.</em>
</details>

